### PR TITLE
options.cwd for default sourceRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ require('espower-loader')({
             'assert.strictEqual(actual, expected, [message])',
             'assert.notStrictEqual(actual, expected, [message])',
             'assert.deepEqual(actual, expected, [message])',
-            'assert.notDeepEqual(actual, expected, [message])'
+            'assert.notDeepEqual(actual, expected, [message])',
+            'assert.deepStrictEqual(actual, expected, [message])',
+            'assert.notDeepStrictEqual(actual, expected, [message])'
         ]
     }
 });

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DESCRIPTION
 
 `espower-loader` applies [espower](http://github.com/power-assert-js/espower) to target sources on loading them. `espower` manipulates assertion expression (JavaScript Code) in the form of ECMAScript AST defined in [The ESTree Spec](https://github.com/estree/estree) (formerly known as [Mozilla SpiderMonkey Parser API](https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API)), to instrument power-assert feature into the code. `espower-loader` also adjusts line and column number in stack traces by using [source-map-support](https://github.com/evanw/node-source-map-support) module.
 
-Please note that `espower-loader` is a beta version product. Pull-requests, issue reports and patches are always welcomed. See [power-assert](http://github.com/power-assert-js/power-assert) project for more documentation.
+Pull-requests, issue reports and patches are always welcomed. See [power-assert](http://github.com/power-assert-js/power-assert) project for more documentation.
 
 
 FYI: You may be interested in [intelli-espower-loader](https://github.com/azu/intelli-espower-loader) to go one step further. With [intelli-espower-loader](https://github.com/azu/intelli-espower-loader), you don't need to create loader file (like `enable-power-assert.js`). Just define test directory in `package.json` wow!

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 var extensions = require.extensions;
 var originalLoader = extensions['.js'];
 var fs = require('fs');
+var extend = require('xtend');
 var minimatch = require('minimatch');
 var convert = require('convert-source-map');
 var sourceMapSupport = require('source-map-support');
@@ -33,11 +34,12 @@ function espowerLoader (options) {
             return originalRetrieveSourceMap(source);
         }
     });
+    var espowerOptions = extend({ sourceRoot: options.cwd }, options.espowerOptions);
 
     extensions['.js'] = function (localModule, filepath) {
         var output;
         if (minimatch(filepath, pattern)){
-            output = espowerSourceToSource(fs.readFileSync(filepath, 'utf-8'), filepath, options.espowerOptions);
+            output = espowerSourceToSource(fs.readFileSync(filepath, 'utf-8'), filepath, espowerOptions);
             var map = convert.fromSource(output).toObject();
             pathToMap[filepath] = map;
             localModule._compile(output, filepath);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git",
     "minimatch": "^2.0.0",
     "source-map-support": "^0.3.0",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -45,10 +45,7 @@
     "test",
     "testing"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/power-assert-js/espower-loader/blob/master/MIT-LICENSE.txt"
-  },
+  "license": "MIT",
   "main": "./index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,18 +11,18 @@
     "url": "https://github.com/power-assert-js/espower-loader/issues"
   },
   "dependencies": {
-    "convert-source-map": "~1.1.0",
+    "convert-source-map": "^1.1.0",
     "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
-    "minimatch": "~2.0.4",
-    "source-map-support": "~0.3.1",
+    "minimatch": "^2.0.0",
+    "source-map-support": "^0.3.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "empower": "~1.0.0",
-    "expect.js": "~0.3.1",
-    "jshint": "~2.8.0",
-    "mocha": "~2.2.5",
-    "power-assert-formatter": "~1.0.0"
+    "empower": "^1.0.0",
+    "expect.js": "^0.3.1",
+    "jshint": "^2.8.0",
+    "mocha": "^2.2.5",
+    "power-assert-formatter": "^1.0.0"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git",
+    "espower-source": "^1.0.0",
     "minimatch": "^2.0.0",
     "source-map-support": "^0.3.0",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   },
   "dependencies": {
     "convert-source-map": "~1.1.0",
-    "espower-source": "~0.10.0",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
     "minimatch": "~2.0.4",
-    "source-map-support": "~0.2.10"
+    "source-map-support": "~0.2.10",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "empower": "~0.11.0",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "empower": "~0.11.0",
+    "empower": "~1.0.0",
     "expect.js": "~0.3.1",
-    "jshint": "~2.7.0",
-    "mocha": "~2.2.4",
-    "power-assert-formatter": "~0.11.0"
+    "jshint": "~2.8.0",
+    "mocha": "~2.2.5",
+    "power-assert-formatter": "~1.0.0"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "convert-source-map": "~1.1.0",
     "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
     "minimatch": "~2.0.4",
-    "source-map-support": "~0.2.10",
+    "source-map-support": "~0.3.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/tobe_instrumented/tobe_instrumented_test.js
+++ b/test/tobe_instrumented/tobe_instrumented_test.js
@@ -4,21 +4,6 @@ var assert = empower(require('assert'), formatter);
 var expect = require('expect.js');
 
 describe('power-assert message', function () {
-    beforeEach(function () {
-        this.expectPowerAssertMessage = function (body, expectedLines, expectedPosition) {
-            try {
-                body();
-            } catch (e) {
-                expect(e.message.split('\n').slice(2, -1)).to.eql(expectedLines.map(function (line) {
-                    return line;
-                }));
-                var re = new RegExp("test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedPosition + "\n");
-                expect(e.stack).to.match(re);
-                return;
-            }
-            expect().fail("AssertionError should be thrown");
-        };
-    });
     
     it('Nested CallExpression with BinaryExpression: assert((three * (seven * ten)) === three);', function () {
         var one = 1, two = 2, three = 3, seven = 7, ten = 10;
@@ -36,7 +21,7 @@ describe('power-assert message', function () {
             '  => 3',
             '  [number] three * (seven * ten)',
             '  => 210'
-        ], '26:13');
+        ], 11, 13);
     });
 
     it('equal with Literal and Identifier: assert.equal(1, minusOne);', function () {
@@ -47,7 +32,22 @@ describe('power-assert message', function () {
             '  assert.equal(1, minusOne)',
             '                  |        ',
             '                  -1       '
-        ], '45:20');
+        ], 30, 20);
     });
 
+    beforeEach(function () {
+        this.expectPowerAssertMessage = function (body, expectedDiagram, expectedLine, expectedColumn) {
+            try {
+                body();
+            } catch (e) {
+                expect(e.message.split('\n').slice(2, -1)).to.eql(expectedDiagram.map(function (line) {
+                    return line;
+                }));
+                expect(e.stack).to.match(new RegExp("test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + ":" + expectedColumn + "\n"));
+                expect(e.stack).to.match(new RegExp("AssertionError:\\s*\\#\\s*test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + "\n"));
+                return;
+            }
+            expect().fail("AssertionError should be thrown");
+        };
+    });
 });


### PR DESCRIPTION
Dealing with `sourceRoot` option to calculate relative paths, and produce correct SourceMap.

Related topics:

- [sourceRoot option by twada · Pull Request #7 · power-assert-js/espower-source](https://github.com/power-assert-js/espower-source/pull/7)
- [sourceRoot option by twada · Pull Request #18 · power-assert-js/espower](https://github.com/power-assert-js/espower/pull/18)
- [convert relative filepath for security reason · Issue #20 · power-assert-js/power-assert](https://github.com/power-assert-js/power-assert/issues/20)