### PR TITLE
upgrade espower-source to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,17 +12,16 @@
   },
   "dependencies": {
     "convert-source-map": "^1.1.0",
-    "espower-source": "^1.0.0",
+    "espower-source": "^2.0.0",
     "minimatch": "^3.0.0",
     "source-map-support": "^0.3.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "empower": "^1.0.0",
     "expect.js": "^0.3.1",
     "jshint": "~2.8.0",
     "mocha": "^2.2.5",
-    "power-assert-formatter": "^1.0.0"
+    "power-assert": "^1.4.2"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/test/not_tobe_instrumented/not_instrumented_test.js
+++ b/test/not_tobe_instrumented/not_instrumented_test.js
@@ -1,6 +1,4 @@
-var empower = require('empower');
-var formatter = require('power-assert-formatter')();
-var assert = empower(require('assert'), formatter);
+var assert = require('assert');
 var expect = require('expect.js');
 
 describe('power-assert client should work with not-instrumented code', function () {

--- a/test/tobe_instrumented/tobe_instrumented_test.js
+++ b/test/tobe_instrumented/tobe_instrumented_test.js
@@ -1,6 +1,4 @@
-var empower = require('empower');
-var formatter = require('power-assert-formatter')();
-var assert = empower(require('assert'), formatter);
+var assert = require('assert');
 var expect = require('expect.js');
 
 describe('power-assert message', function () {
@@ -21,7 +19,7 @@ describe('power-assert message', function () {
             '  => 3',
             '  [number] three * (seven * ten)',
             '  => 210'
-        ], 11, 13);
+        ], 9, 13);
     });
 
     it('equal with Literal and Identifier: assert.equal(1, minusOne);', function () {
@@ -32,7 +30,7 @@ describe('power-assert message', function () {
             '  assert.equal(1, minusOne)',
             '                  |        ',
             '                  -1       '
-        ], 30, 20);
+        ], 28, 20);
     });
 
     beforeEach(function () {
@@ -44,7 +42,7 @@ describe('power-assert message', function () {
                     return line;
                 }));
                 expect(e.stack).to.match(new RegExp("test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + ":" + expectedColumn + "\n"));
-                expect(e.stack).to.match(new RegExp("AssertionError:\\s*\\#\\s*test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + "\n"));
+                expect(e.message).to.match(new RegExp("\\s*\\#\\s*test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + "\n"));
                 return;
             }
             expect().fail("AssertionError should be thrown");


### PR DESCRIPTION
Now `require('assert')` in tests are empowered transparently

see:

- [Integrate `empower-assert` to enable transparent assertion enhancement](https://github.com/power-assert-js/espower-source/pull/11)
- [Embed value capturing helper into transpiled code](https://github.com/power-assert-js/espower/pull/26)
