### PR TITLE
chore(package): update source-map-support to 0.4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ var extend = require('xtend');
 var minimatch = require('minimatch');
 var convert = require('convert-source-map');
 var sourceMapSupport = require('source-map-support');
-var originalRetrieveSourceMap = sourceMapSupport.retrieveSourceMap;
 var espowerSourceToSource = require('espower-source');
 var pathToMap = {};
 
@@ -29,10 +28,11 @@ function espowerLoader (options) {
         retrieveSourceMap: function (source) {
             if (minimatch(source, pattern) && pathToMap[source]) {
                 return {
-                    map: pathToMap[source]
+                    map: pathToMap[source],
+                    url: source,
                 };
             }
-            return originalRetrieveSourceMap(source);
+            return null;
         }
     });
     var espowerOptions = extend({ sourceRoot: options.cwd }, options.espowerOptions);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "convert-source-map": "^1.1.0",
     "espower-source": "^2.0.0",
     "minimatch": "^3.0.0",
-    "source-map-support": "^0.3.0",
+    "source-map-support": "^0.4.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Now, The package source-map-support is out of date.

The 0.3.x version has some problem with sourceMap path. And If some one use source-map-support in they own project(which must be the latest version), so The source-map-support will load twice, which may lead to some weird bug.