### PR TITLE
fix: fix the filepath of the stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function espowerLoader (options) {
             if (minimatch(source, pattern) && pathToMap[source]) {
                 return {
                     map: pathToMap[source],
-                    url: source
                 };
             }
             return null;

--- a/test/tobe_instrumented/tobe_instrumented_test.js
+++ b/test/tobe_instrumented/tobe_instrumented_test.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var expect = require('expect.js');
 
 describe('power-assert message', function () {
-    
+
     it('Nested CallExpression with BinaryExpression: assert((three * (seven * ten)) === three);', function () {
         var one = 1, two = 2, three = 3, seven = 7, ten = 10;
         this.expectPowerAssertMessage(function () {
@@ -41,7 +41,7 @@ describe('power-assert message', function () {
                 expect(e.message.split('\n').slice(2, -1)).to.eql(expectedDiagram.map(function (line) {
                     return line;
                 }));
-                expect(e.stack).to.match(new RegExp("test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + ":" + expectedColumn + "\n"));
+                expect(e.stack).to.match(new RegExp("at test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + ":" + expectedColumn + "\n"));
                 expect(e.message).to.match(new RegExp("\\s*\\#\\s*test\/tobe_instrumented\/tobe_instrumented_test.js:" + expectedLine + "\n"));
                 return;
             }


### PR DESCRIPTION
This error is introduced by #6 

## How to reproduce

```js
// index.js
require('intelli-espower-loader');
require('./test/index.test.js');

// test/index.test.js
throw new Error(1);
```

run `node index.js`, then you can see the wrong path `/Users/popomore/code/tmp/test/test/index.test.js`

```
/Users/popomore/code/tmp/test/test/index.test.js:1
throw new Error(1);
      ^
Error: 1
    at Object.<anonymous> (/Users/popomore/code/tmp/test/test/index.test.js:1:7)
    at Module._compile (module.js:570:32)
    at Object.extensions..js (/Users/popomore/code/tmp/node_modules/.1.2.1@espower-loader/index.js:46:25)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/popomore/code/tmp/index.js:2:1)
    at Module._compile (module.js:570:32)
```
